### PR TITLE
Add dark mode option

### DIFF
--- a/about.php
+++ b/about.php
@@ -60,6 +60,11 @@ if (file_exists($teamFile)) {
                 </ul>
                 
                 <ul class="navbar-nav">
+                    <li class="nav-item">
+                        <button class="btn btn-outline-light btn-sm" id="darkModeToggle" title="Modo oscuro">
+                            <i class="fas fa-moon"></i>
+                        </button>
+                    </li>
                     <li class="nav-item me-3">
                         <a class="nav-link position-relative" href="cart.php">
                             <i class="fas fa-shopping-cart fs-5"></i>

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1322,4 +1322,22 @@ footer a:hover {
         animation-iteration-count: 1 !important;
         transition-duration: 0.01ms !important;
     }
-} 
+}
+
+/* Dark Mode Styles */
+body.dark-mode {
+    background-color: var(--gray-900);
+    color: var(--gray-100);
+}
+body.dark-mode .navbar {
+    background-color: var(--dark-color) !important;
+}
+body.dark-mode .card,
+body.dark-mode .product-card,
+body.dark-mode .category-card {
+    background-color: var(--gray-800);
+    color: var(--gray-100);
+}
+body.dark-mode .section {
+    background-color: var(--gray-800);
+}

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -9,7 +9,8 @@ document.addEventListener('DOMContentLoaded', function() {
     initializeParallax();
     initializeCounters();
     initializeTypingEffect();
-    
+    initializeDarkMode();
+
     // Add loading screen
     hideLoadingScreen();
 });
@@ -411,6 +412,31 @@ function initializeTypingEffect() {
         
         observer.observe(element);
     });
+}
+
+// Dark Mode Toggle
+function initializeDarkMode() {
+    const toggle = document.getElementById('darkModeToggle');
+    const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+    const savedMode = localStorage.getItem('darkMode');
+
+    if (savedMode === 'enabled' || (savedMode === null && prefersDark)) {
+        document.body.classList.add('dark-mode');
+        if (toggle) toggle.innerHTML = '<i class="fas fa-sun"></i>';
+    }
+
+    if (toggle) {
+        toggle.addEventListener('click', () => {
+            document.body.classList.toggle('dark-mode');
+            if (document.body.classList.contains('dark-mode')) {
+                localStorage.setItem('darkMode', 'enabled');
+                toggle.innerHTML = '<i class="fas fa-sun"></i>';
+            } else {
+                localStorage.setItem('darkMode', 'disabled');
+                toggle.innerHTML = '<i class="fas fa-moon"></i>';
+            }
+        });
+    }
 }
 
 // Enhanced Notifications

--- a/cart.php
+++ b/cart.php
@@ -53,6 +53,11 @@ $product = new Product();
                 </ul>
                 
                 <ul class="navbar-nav">
+                    <li class="nav-item">
+                        <button class="btn btn-outline-light btn-sm" id="darkModeToggle" title="Modo oscuro">
+                            <i class="fas fa-moon"></i>
+                        </button>
+                    </li>
                     <li class="nav-item me-3">
                         <a class="nav-link position-relative active" href="cart.php">
                             <i class="fas fa-shopping-cart fs-5"></i>

--- a/category.php
+++ b/category.php
@@ -77,6 +77,11 @@ $totalPages = ceil($totalProducts / $limit);
                 </ul>
                 
                 <ul class="navbar-nav">
+                    <li class="nav-item">
+                        <button class="btn btn-outline-light btn-sm" id="darkModeToggle" title="Modo oscuro">
+                            <i class="fas fa-moon"></i>
+                        </button>
+                    </li>
                     <li class="nav-item me-3">
                         <a class="nav-link position-relative" href="cart.php">
                             <i class="fas fa-shopping-cart fs-5"></i>

--- a/contact.php
+++ b/contact.php
@@ -50,6 +50,11 @@ require_once 'config/config.php';
                 </ul>
                 
                 <ul class="navbar-nav">
+                    <li class="nav-item">
+                        <button class="btn btn-outline-light btn-sm" id="darkModeToggle" title="Modo oscuro">
+                            <i class="fas fa-moon"></i>
+                        </button>
+                    </li>
                     <li class="nav-item me-3">
                         <a class="nav-link position-relative" href="cart.php">
                             <i class="fas fa-shopping-cart fs-5"></i>

--- a/index.php
+++ b/index.php
@@ -90,6 +90,11 @@ if ($heroImage && strpos($heroImage, 'http') !== 0) {
                 </ul>
                 
                 <ul class="navbar-nav">
+                    <li class="nav-item">
+                        <button class="btn btn-outline-light btn-sm" id="darkModeToggle" title="Modo oscuro">
+                            <i class="fas fa-moon"></i>
+                        </button>
+                    </li>
                     <li class="nav-item me-3">
                         <a class="nav-link position-relative" href="cart.php">
                             <i class="fas fa-shopping-cart fs-5"></i>

--- a/orders.php
+++ b/orders.php
@@ -86,6 +86,11 @@ if ($orderId) {
                 </ul>
                 
                 <ul class="navbar-nav">
+                    <li class="nav-item">
+                        <button class="btn btn-outline-light btn-sm" id="darkModeToggle" title="Modo oscuro">
+                            <i class="fas fa-moon"></i>
+                        </button>
+                    </li>
                     <li class="nav-item me-3">
                         <a class="nav-link position-relative" href="cart.php">
                             <i class="fas fa-shopping-cart fs-5"></i>

--- a/product.php
+++ b/product.php
@@ -102,6 +102,11 @@ unset($rp);
                 </ul>
                 
                 <ul class="navbar-nav">
+                    <li class="nav-item">
+                        <button class="btn btn-outline-light btn-sm" id="darkModeToggle" title="Modo oscuro">
+                            <i class="fas fa-moon"></i>
+                        </button>
+                    </li>
                     <li class="nav-item me-3">
                         <a class="nav-link position-relative" href="cart.php">
                             <i class="fas fa-shopping-cart fs-5"></i>

--- a/products.php
+++ b/products.php
@@ -89,6 +89,11 @@ $categories = $category->getAllCategories();
                 </ul>
                 
                 <ul class="navbar-nav">
+                    <li class="nav-item">
+                        <button class="btn btn-outline-light btn-sm" id="darkModeToggle" title="Modo oscuro">
+                            <i class="fas fa-moon"></i>
+                        </button>
+                    </li>
                     <li class="nav-item me-3">
                         <a class="nav-link position-relative" href="cart.php">
                             <i class="fas fa-shopping-cart fs-5"></i>

--- a/profile.php
+++ b/profile.php
@@ -66,6 +66,11 @@ $userOrders = $order->getOrdersByUserId($_SESSION['user_id']);
                 </ul>
                 
                 <ul class="navbar-nav">
+                    <li class="nav-item">
+                        <button class="btn btn-outline-light btn-sm" id="darkModeToggle" title="Modo oscuro">
+                            <i class="fas fa-moon"></i>
+                        </button>
+                    </li>
                     <li class="nav-item me-3">
                         <a class="nav-link position-relative" href="cart.php">
                             <i class="fas fa-shopping-cart fs-5"></i>


### PR DESCRIPTION
## Summary
- add dark mode toggle button in navigation
- implement dark mode styles in CSS
- support preference persistence via new JS helper

## Testing
- `USE_SQLITE=1 php test_system.php | tr -d '\n' | cut -c1-500`
- `USE_SQLITE=1 php test_system.php | tr -d '\n' | cut -c501-1000`
- `USE_SQLITE=1 php test_system.php | tr -d '\n' | cut -c1001-1500`
- `USE_SQLITE=1 php test_system.php | tr -d '\n' | cut -c1501-2000`

------
https://chatgpt.com/codex/tasks/task_b_68782956e680833396c50862cd283bbb