### PR TITLE
Fix category discount warning and remove free shipping text

### DIFF
--- a/category.php
+++ b/category.php
@@ -211,7 +211,7 @@ $totalPages = ceil($totalProducts / $limit);
                                             <i class="fas fa-heart"></i>
                                         </button>
                                     </div>
-                                    <?php if ($prod['discount_percentage'] > 0): ?>
+                                    <?php if (isset($prod['discount_percentage']) && $prod['discount_percentage'] > 0): ?>
                                         <span class="badge bg-danger position-absolute top-0 start-0 m-2 pulse">
                                             -<?php echo $prod['discount_percentage']; ?>%
                                         </span>
@@ -245,7 +245,7 @@ $totalPages = ceil($totalProducts / $limit);
                                     
                                     <div class="d-flex justify-content-between align-items-center mb-3">
                                         <div class="price">
-                                            <?php if ($prod['discount_percentage'] > 0): ?>
+                                            <?php if (isset($prod['discount_percentage']) && $prod['discount_percentage'] > 0): ?>
                                                 <span class="text-decoration-line-through text-muted me-2">
                                                     $<?php echo number_format($prod['price'], 0, ',', '.'); ?>
                                                 </span>
@@ -256,10 +256,6 @@ $totalPages = ceil($totalProducts / $limit);
                                                 <span class="fw-bold text-primary">$<?php echo number_format($prod['price'], 0, ',', '.'); ?></span>
                                             <?php endif; ?>
                                         </div>
-                                        <small class="text-muted">
-                                            <i class="fas fa-truck me-1"></i>
-                                            Envío gratis
-                                        </small>
                                     </div>
                                     
                                     <div class="d-grid gap-2">
@@ -267,7 +263,7 @@ $totalPages = ceil($totalProducts / $limit);
                                             <i class="fas fa-cart-plus me-2"></i>
                                             Agregar al Carrito
                                         </button>
-                                        <a href="https://wa.me/593983015307?text=Hola%2C%20quiero%20comprar%20el%20producto:%20<?php echo urlencode($prod['name']); ?>%20-%20$<?php echo number_format($prod['discount_percentage'] > 0 ? $prod['price'] * (1 - $prod['discount_percentage'] / 100) : $prod['price'], 0, ',', '.'); ?>%20-%20AlquimiaTechnologic" 
+                                        <a href="https://wa.me/593983015307?text=Hola%2C%20quiero%20comprar%20el%20producto:%20<?php echo urlencode($prod['name']); ?>%20-%20$<?php echo number_format((isset($prod['discount_percentage']) && $prod['discount_percentage'] > 0) ? $prod['price'] * (1 - $prod['discount_percentage'] / 100) : $prod['price'], 0, ',', '.'); ?>%20-%20AlquimiaTechnologic"
                                            class="btn btn-success btn-sm hover-lift" target="_blank">
                                             <i class="fab fa-whatsapp me-2"></i>
                                             Comprar por WhatsApp

--- a/product.php
+++ b/product.php
@@ -272,10 +272,6 @@ unset($rp);
                                 </li>
                                 <li class="mb-2">
                                     <i class="fas fa-check text-success me-2"></i>
-                                    Envío gratis en todo el país
-                                </li>
-                                <li class="mb-2">
-                                    <i class="fas fa-check text-success me-2"></i>
                                     Garantía de 30 días
                                 </li>
                                 <li class="mb-2">
@@ -327,10 +323,6 @@ unset($rp);
                         <!-- Shipping Info -->
                         <div class="shipping-info p-3 bg-light rounded">
                             <div class="row">
-                                <div class="col-md-6 mb-2">
-                                    <i class="fas fa-truck text-primary me-2"></i>
-                                    <span class="text-muted">Envío gratis</span>
-                                </div>
                                 <div class="col-md-6 mb-2">
                                     <i class="fas fa-shield-alt text-success me-2"></i>
                                     <span class="text-muted">Garantía 30 días</span>

--- a/products.php
+++ b/products.php
@@ -337,10 +337,6 @@ $categories = $category->getAllCategories();
                                                 <span class="fw-bold text-primary">$<?php echo number_format($prod['price'], 0, ',', '.'); ?></span>
                                             <?php endif; ?>
                                         </div>
-                                        <small class="text-muted">
-                                            <i class="fas fa-truck me-1"></i>
-                                            Envío gratis
-                                        </small>
                                     </div>
                                     
                                     <div class="d-grid gap-2">


### PR DESCRIPTION
## Summary
- check `discount_percentage` on category page before using it
- remove `Envío gratis` text from product listings

## Testing
- `php -l category.php`
- `php -l product.php`
- `php -l products.php`


------
https://chatgpt.com/codex/tasks/task_b_68782c8a36a0833390258dc750767306