### PR TITLE
Fix featured badge check

### DIFF
--- a/category.php
+++ b/category.php
@@ -216,7 +216,7 @@ $totalPages = ceil($totalProducts / $limit);
                                             -<?php echo $prod['discount_percentage']; ?>%
                                         </span>
                                     <?php endif; ?>
-                                    <?php if ($prod['featured']): ?>
+                                    <?php if (isset($prod['is_featured']) && $prod['is_featured']): ?>
                                         <span class="badge bg-warning position-absolute top-0 end-0 m-2">
                                             <i class="fas fa-star"></i> Destacado
                                         </span>

--- a/products.php
+++ b/products.php
@@ -291,7 +291,7 @@ $categories = $category->getAllCategories();
                                             -<?php echo $prod['discount_percentage']; ?>%
                                         </span>
                                     <?php endif; ?>
-                                    <?php if (isset($prod['featured']) && $prod['featured']): ?>
+                                    <?php if (isset($prod['is_featured']) && $prod['is_featured']): ?>
                                         <span class="badge bg-warning position-absolute top-0 end-0 m-2">
                                             <i class="fas fa-star"></i> Destacado
                                         </span>


### PR DESCRIPTION
## Summary
- prevent warning in category and products pages by checking `is_featured` field

## Testing
- `USE_SQLITE=1 php -f test_system.php | tr '<' '\n' | grep -E '✅|❌' | head`
- `USE_SQLITE=1 php -f test_upload_simple.php | tr '<' '\n' | grep -E '✅|❌' | head`
- `USE_SQLITE=1 php -f check_database_connection.php | tr '<' '\n' | grep -E '✅|❌' | head`

------
https://chatgpt.com/codex/tasks/task_b_68782fbb3620833384ec7795549a28cc