### PR TITLE
Fix cart details and add about image setting

### DIFF
--- a/about.php
+++ b/about.php
@@ -10,6 +10,10 @@ if (file_exists($teamFile)) {
         $teamMembers = $data;
     }
 }
+$aboutImage = getSiteSetting('about_image_url', 'assets/images/placeholder.jpg');
+if ($aboutImage && strpos($aboutImage, 'http') !== 0) {
+    $aboutImage = rtrim(SITE_URL, '/') . '/' . ltrim($aboutImage, '/');
+}
 ?>
 <!DOCTYPE html>
 <html lang="es">
@@ -162,7 +166,7 @@ if (file_exists($teamFile)) {
                     </div>
                 </div>
                 <div class="col-lg-6" data-aos="fade-left">
-                    <img src="assets/images/placeholder.jpg"
+                    <img src="<?php echo htmlspecialchars($aboutImage); ?>"
                            alt="Nuestra Historia" class="img-fluid rounded-custom shadow-lg">
                 </div>
             </div>

--- a/api/get_products.php
+++ b/api/get_products.php
@@ -1,0 +1,36 @@
+<?php
+require_once __DIR__ . '/../config/config.php';
+require_once __DIR__ . '/../classes/Product.php';
+
+header('Content-Type: application/json');
+header('Access-Control-Allow-Origin: *');
+
+$idsParam = $_GET['ids'] ?? '';
+if (!$idsParam) {
+    echo json_encode(['success' => false, 'message' => 'No ids provided']);
+    exit;
+}
+
+$ids = array_filter(array_map('intval', explode(',', $idsParam)), function($id) { return $id > 0; });
+if (empty($ids)) {
+    echo json_encode(['success' => false, 'message' => 'No valid ids']);
+    exit;
+}
+
+$product = new Product();
+$products = [];
+foreach ($ids as $id) {
+    $p = $product->getProductById($id);
+    if ($p) {
+        $p['image'] = Product::getImagePath($p);
+        $products[] = [
+            'id' => (int)$p['id'],
+            'name' => $p['name'],
+            'price' => (float)$p['price'],
+            'image' => $p['image'],
+            'slug' => $p['slug']
+        ];
+    }
+}
+
+echo json_encode(['success' => true, 'products' => $products]);

--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -424,6 +424,9 @@ function updateImagesJson() {
             } else if (hiddenInput.id === 'heroImagesJson') {
                 const urlInput = document.getElementById('heroImageUrl');
                 if (urlInput) urlInput.value = images[0] || '';
+            } else if (hiddenInput.id === 'aboutImagesJson') {
+                const urlInput = document.getElementById('aboutImageUrl');
+                if (urlInput) urlInput.value = images[0] || '';
             }
         }
     });

--- a/data/settings.json
+++ b/data/settings.json
@@ -14,5 +14,6 @@
   "favicon_url": "",
   "maintenance_mode": false,
   "allow_registration": true,
-  "email_notifications": true
+  "email_notifications": true,
+  "about_image_url": "assets/images/placeholder.jpg"
 }


### PR DESCRIPTION
## Summary
- allow custom image for the "Nuestra Historia" section
- show newly uploaded "Nuestra Historia" image in the about page
- add backend API to fetch cart product data
- fetch real product info when displaying the cart
- update admin panel JS helpers

## Testing
- `php -l api/get_products.php`
- `php -l about.php`
- `php -l admin/settings.php`
- `php -l cart.php`
- `node -e "require('fs').readFile('assets/js/admin.js', 'utf8', (e,d)=>{if(e)process.exit(1);try{new Function(d)}catch(err){console.error(err);process.exit(1);}})"`
- `USE_SQLITE=1 php -f test_system.php | head -c 1500`
- `USE_SQLITE=1 php -f test_upload_simple.php | head -c 1500`


------
https://chatgpt.com/codex/tasks/task_b_68785ece15808333b20177d3310ad74a